### PR TITLE
Populate officer details in POST request to create auth-code-request

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestGetConfig(t *testing.T) {
+func TestUnitGetConfig(t *testing.T) {
 	Convey("Successful Get Config", t, func() {
 		os.Setenv("BIND_ADDR", "123")
 		config, err := Get()

--- a/handlers/create_auth_code_request.go
+++ b/handlers/create_auth_code_request.go
@@ -59,7 +59,6 @@ func CreateAuthCodeRequest(authCodeSvc *service.AuthCodeService, authCodeReqSvc 
 			return
 		}
 
-		log.Info(officer.UsualResidentialAddress.ID)
 		request.OfficerUraID = officer.UsualResidentialAddress.ID
 		request.OfficerForename = officer.Forename
 		request.OfficerSurname = officer.Surname

--- a/models/request_entities.go
+++ b/models/request_entities.go
@@ -4,8 +4,11 @@ import "github.com/companieshouse/chs.go/authentication"
 
 // AuthCodeRequest is the data received when creating a new Auth Code Request.
 type AuthCodeRequest struct {
-	CompanyNumber string                         `json:"company_number" validate:"required"`
-	CreatedBy     authentication.AuthUserDetails `json:",omitempty" validate:"required"`
-	OfficerID     string                         `json:"officer_id" validate:"required"`
-	Status        string                         `json:"status"`
+	CompanyNumber   string                         `json:"company_number" validate:"required"`
+	CreatedBy       authentication.AuthUserDetails `json:",omitempty" validate:"required"`
+	OfficerID       string                         `json:"officer_id" validate:"required"`
+	Status          string                         `json:"status"`
+	OfficerUraID    string                         `json:"officer_ura_id"`
+	OfficerForename string                         `json:"officer_forename"`
+	OfficerSurname  string                         `json:"officer_surname"`
 }

--- a/oracle/client_test.go
+++ b/oracle/client_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestGetOfficers(t *testing.T) {
+func TestUnitGetOfficers(t *testing.T) {
 	companyNumber := "87654321"
 
 	Convey("Get Officer List", t, func() {

--- a/oracle/types.go
+++ b/oracle/types.go
@@ -19,7 +19,7 @@ type Officer struct {
 	Nationality             string      `json:"nationality"`
 	CountryOfResidence      string      `json:"country_of_residence"`
 	Occupation              string      `json:"occupation"`
-	UsualResidentialAddress Address     `json:"address"`
+	UsualResidentialAddress Address     `json:"usual_residential_address"`
 }
 
 // DateOfBirth is the month and year of an officer's date of birth

--- a/service/officers.go
+++ b/service/officers.go
@@ -34,8 +34,24 @@ func GetOfficers(companyNumber string) (*models.OfficerListResponse, ResponseTyp
 	return resp, Success, nil
 }
 
-// GetOfficer returns the list of officers for the supplied company number
+// GetOfficer returns a single officer to be returned by the API for the supplied company number and officer id
 func GetOfficer(companyNumber, officerID string) (*models.Officer, ResponseType, error) {
+	oracleAPIResponse, responseType, err := GetOfficerDetails(companyNumber, officerID)
+	if err != nil {
+		return nil, Error, err
+	}
+	if responseType != Success {
+		return nil, responseType, nil
+	}
+
+	resp := transformers.OfficerResponse(oracleAPIResponse)
+
+	return resp, Success, nil
+
+}
+
+// GetOfficerDetails returns a single officer with values such as URA to be used internally only
+func GetOfficerDetails(companyNumber, officerID string) (*oracle.Officer, ResponseType, error) {
 	cfg, err := config.Get()
 	if err != nil {
 		return nil, Error, nil
@@ -53,8 +69,5 @@ func GetOfficer(companyNumber, officerID string) (*models.Officer, ResponseType,
 		return nil, NotFound, nil
 	}
 
-	resp := transformers.OfficerResponse(oracleAPIResponse)
-
-	return resp, Success, nil
-
+	return oracleAPIResponse, Success, nil
 }

--- a/service/officers_test.go
+++ b/service/officers_test.go
@@ -22,7 +22,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			resp, respType, err := GetOfficers(companyNumber)
 			So(resp, ShouldBeNil)
 			So(respType, ShouldEqual, Error)
-			So(err.Error(), ShouldContainSubstring, url)
+			So(err.Error(), ShouldContainSubstring, "no responder found")
 		})
 
 		Convey("Empty response", func() {
@@ -62,7 +62,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			resp, respType, err := GetOfficer(companyNumber, officerID)
 			So(resp, ShouldBeNil)
 			So(respType, ShouldEqual, Error)
-			So(err.Error(), ShouldContainSubstring, url)
+			So(err.Error(), ShouldContainSubstring, "no responder found")
 		})
 
 		Convey("Empty response", func() {

--- a/service/officers_test.go
+++ b/service/officers_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestGetOfficers(t *testing.T) {
+func TestUnitGetOfficers(t *testing.T) {
 	companyNumber := "87654321"
 
 	Convey("Get Officer List", t, func() {

--- a/service/officers_test.go
+++ b/service/officers_test.go
@@ -22,7 +22,7 @@ func TestGetOfficers(t *testing.T) {
 			resp, respType, err := GetOfficers(companyNumber)
 			So(resp, ShouldBeNil)
 			So(respType, ShouldEqual, Error)
-			So(err, ShouldBeError, `Get "`+url+`": no responder found`)
+			So(err, ShouldBeError, "Get "+url+": no responder found")
 		})
 
 		Convey("Empty response", func() {
@@ -62,7 +62,7 @@ func TestGetOfficers(t *testing.T) {
 			resp, respType, err := GetOfficer(companyNumber, officerID)
 			So(resp, ShouldBeNil)
 			So(respType, ShouldEqual, Error)
-			So(err, ShouldBeError, `Get "`+url+`": no responder found`)
+			So(err, ShouldBeError, "Get "+url+": no responder found")
 		})
 
 		Convey("Empty response", func() {

--- a/service/officers_test.go
+++ b/service/officers_test.go
@@ -22,7 +22,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			resp, respType, err := GetOfficers(companyNumber)
 			So(resp, ShouldBeNil)
 			So(respType, ShouldEqual, Error)
-			So(err, ShouldBeError, "Get "+url+": no responder found")
+			So(err.Error(), ShouldContainSubstring, url)
 		})
 
 		Convey("Empty response", func() {
@@ -62,7 +62,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			resp, respType, err := GetOfficer(companyNumber, officerID)
 			So(resp, ShouldBeNil)
 			So(respType, ShouldEqual, Error)
-			So(err, ShouldBeError, "Get "+url+": no responder found")
+			So(err.Error(), ShouldContainSubstring, url)
 		})
 
 		Convey("Empty response", func() {

--- a/service/response_type_test.go
+++ b/service/response_type_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestResponseType(t *testing.T) {
+func TestUnitResponseType(t *testing.T) {
 	Convey("Successful Get Response Type", t, func() {
 		So(NotFound.String(), ShouldEqual, "not-found")
 	})

--- a/transformers/authcode_request_resource.go
+++ b/transformers/authcode_request_resource.go
@@ -31,9 +31,9 @@ func AuthCodeResourceRequestToDB(req *models.AuthCodeRequest) *models.AuthCodeRe
 		Data: models.AuthCodeRequestDataDao{
 			CompanyNumber:   req.CompanyNumber,
 			OfficerID:       req.OfficerID,
-			OfficerUraID:    "", // TODO
-			OfficerForename: "", // TODO
-			OfficerSurname:  "", // TODO
+			OfficerUraID:    req.OfficerUraID,
+			OfficerForename: req.OfficerForename,
+			OfficerSurname:  req.OfficerSurname,
 			Status:          "pending",
 			CreatedAt:       &createdAt,
 			SubmittedAt:     nil,

--- a/transformers/officers_test.go
+++ b/transformers/officers_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestOfficerTransformation(t *testing.T) {
+func TestUnitOfficerTransformation(t *testing.T) {
 	Convey("Officer List", t, func() {
 		Convey("Response correctly converted", func() {
 			input := oracle.GetOfficersResponse{


### PR DESCRIPTION
When the POST request is made to create an emergency-auth-code-request in Mongo then the oracle-query-api gets called to return details for the specified officer.

Resolves: BI-3353