### PR TITLE
Update submitted_at field

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -107,8 +107,9 @@ func (m *MongoService) UpdateAuthCodeRequestStatus(dao *models.AuthCodeRequestRe
 	filter := bson.M{"_id": dao.ID}
 	update := bson.M{
 		"$set": bson.M{
-			"data.status": dao.Data.Status,
-			"data.type":   dao.Data.Type,
+			"data.status":       dao.Data.Status,
+			"data.type":         dao.Data.Type,
+			"data.submitted_at": dao.Data.SubmittedAt,
 		},
 	}
 

--- a/handlers/auth_code_request_update_test.go
+++ b/handlers/auth_code_request_update_test.go
@@ -212,7 +212,7 @@ func TestUnitUpdateAuthCodeRequestHandler(t *testing.T) {
 				}
 
 				mockDaoReqService := mocks.NewMockAuthcodeRequestDAOService(mockCtrl)
-				mockDaoReqService.EXPECT().GetAuthCodeRequest("123").Return(&authCodeDaoResponse, nil)
+				mockDaoReqService.EXPECT().GetAuthCodeRequest("123").Return(&authCodeDaoResponse, nil).AnyTimes()
 				mockDaoReqService.EXPECT().UpdateAuthCodeRequestOfficer(gomock.Any()).Return(nil)
 
 				httpmock.Activate()
@@ -361,7 +361,7 @@ func TestUnitUpdateAuthCodeRequestHandler(t *testing.T) {
 				}
 
 				mockDaoReqService := mocks.NewMockAuthcodeRequestDAOService(mockCtrl)
-				mockDaoReqService.EXPECT().GetAuthCodeRequest("123").Return(&authCodeDaoResponse, nil)
+				mockDaoReqService.EXPECT().GetAuthCodeRequest("123").Return(&authCodeDaoResponse, nil).AnyTimes()
 				mockDaoReqService.EXPECT().UpdateAuthCodeRequestStatus(gomock.Any()).Return(nil)
 
 				mockDaoAuthcodeService := mocks.NewMockAuthcodeDAOService(mockCtrl)

--- a/models/data_entities.go
+++ b/models/data_entities.go
@@ -20,7 +20,7 @@ type AuthCodeRequestDataDao struct {
 	OfficerSurname  string       `bson:"officer_surname"`
 	Status          string       `bson:"status"`
 	CreatedAt       *time.Time   `bson:"created_at"`
-	SubmittedAt     *time.Time   `bson:"submittedAt"`
+	SubmittedAt     *time.Time   `bson:"submitted_at"`
 	Kind            string       `bson:"kind"`
 	Etag            string       `bson:"etag"`
 	CreatedBy       CreatedByDao `bson:"created_by"`

--- a/service/auth_code_request.go
+++ b/service/auth_code_request.go
@@ -92,9 +92,6 @@ func (s *AuthCodeRequestService) UpdateAuthCodeRequestStatusSubmitted(authCodeRe
 		return Error
 	}
 
-	// authCodeReqDao.Data.Status = submitted
-	// authCodeReqDao.Data.SubmittedAt = &submittedAt
-
 	return Success
 }
 

--- a/service/auth_code_request_test.go
+++ b/service/auth_code_request_test.go
@@ -28,7 +28,7 @@ func TestUnitUpdateAuthCodeRequestOfficer(t *testing.T) {
 			authCodeReq := models.AuthCodeRequestResourceDao{}
 			officer := oracle.Officer{}
 
-			_, responseType := svc.UpdateAuthCodeRequestOfficer(&authCodeReq, "123", &officer)
+			responseType := svc.UpdateAuthCodeRequestOfficer(&authCodeReq, "123", &officer)
 			So(responseType, ShouldEqual, Error)
 		})
 
@@ -43,7 +43,7 @@ func TestUnitUpdateAuthCodeRequestOfficer(t *testing.T) {
 			authCodeReq := models.AuthCodeRequestResourceDao{}
 			officer := oracle.Officer{}
 
-			_, responseType := svc.UpdateAuthCodeRequestOfficer(&authCodeReq, "123", &officer)
+			responseType := svc.UpdateAuthCodeRequestOfficer(&authCodeReq, "123", &officer)
 			So(responseType, ShouldEqual, Success)
 		})
 	})
@@ -62,7 +62,7 @@ func TestUnitUpdateAuthCodeRequestStatus(t *testing.T) {
 
 			authCodeReq := models.AuthCodeRequestResourceDao{}
 
-			_, responseType := svc.UpdateAuthCodeRequestStatus(&authCodeReq, "123", "submitted", false)
+			responseType := svc.UpdateAuthCodeRequestStatusSubmitted(&authCodeReq, "123", false)
 			So(responseType, ShouldEqual, Error)
 		})
 
@@ -76,7 +76,7 @@ func TestUnitUpdateAuthCodeRequestStatus(t *testing.T) {
 
 			authCodeReq := models.AuthCodeRequestResourceDao{}
 
-			_, responseType := svc.UpdateAuthCodeRequestStatus(&authCodeReq, "123", "submitted", false)
+			responseType := svc.UpdateAuthCodeRequestStatusSubmitted(&authCodeReq, "123", false)
 			So(responseType, ShouldEqual, Success)
 		})
 	})


### PR DESCRIPTION
Update `submitted_at` field in DB and response when item is submitted.

This change includes making a second request to read the request from the DB, to make sure that the date in the response is returned in the correct format.