### PR TITLE
Check the filing history of the company

### DIFF
--- a/handlers/auth_code_request_create.go
+++ b/handlers/auth_code_request_create.go
@@ -76,6 +76,20 @@ func CreateAuthCodeRequest(authCodeReqSvc *service.AuthCodeRequestService) http.
 			}
 		}
 
+		hasFiledWithinPeriod, err := service.CheckCompanyFilingHistory(request.CompanyNumber)
+		if err != nil {
+			log.ErrorR(req, fmt.Errorf("error calling Oracle API to check filing history: %v", err))
+			m := models.NewMessageResponse("there was a problem communicating with the Oracle API")
+			utils.WriteJSONWithStatus(w, req, m, http.StatusInternalServerError)
+			return
+		}
+		if hasFiledWithinPeriod {
+			log.Info(fmt.Sprintf("company has had a filing within a recent period: %v", request.CompanyNumber))
+			m := models.NewMessageResponse("the company has had a filing within a recent period")
+			utils.WriteJSONWithStatus(w, req, m, http.StatusForbidden)
+			return
+		}
+
 		model := transformers.AuthCodeResourceRequestToDB(&request)
 
 		companyName, err := service.GetCompanyName(request.CompanyNumber, req)

--- a/handlers/auth_code_request_create_test.go
+++ b/handlers/auth_code_request_create_test.go
@@ -95,34 +95,6 @@ func TestUnitCreateAuthCodeRequestHandler(t *testing.T) {
 			So(res.Body.String(), ShouldStartWith, `{"message":"company number missing from request"}`)
 		})
 
-		Convey("error calling oracle API for officer", func() {
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-			defer httpmock.Reset()
-
-			// stub the oracle query lookup
-			responder := httpmock.NewStringResponder(http.StatusBadRequest, `{"total_results":3}`)
-			httpmock.RegisterResponder(http.MethodGet, "/emergency-auth-code/company/87654321/eligible-officers/12345678", responder)
-
-			res := serveCreateAuthCodeRequestHandler(context.WithValue(context.Background(), authentication.ContextKeyUserDetails, authentication.AuthUserDetails{}), t, &models.AuthCodeRequest{CompanyNumber: "87654321", OfficerID: "12345678"}, nil)
-			So(res.Code, ShouldEqual, http.StatusInternalServerError)
-			So(res.Body.String(), ShouldStartWith, `{"message":"there was a problem communicating with the Oracle API"}`)
-		})
-
-		Convey("no officer with that ID found for company", func() {
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-			defer httpmock.Reset()
-
-			// stub the oracle query lookup
-			responder := httpmock.NewStringResponder(http.StatusNotFound, `{"total_results":3}`)
-			httpmock.RegisterResponder(http.MethodGet, "/emergency-auth-code/company/87654321/eligible-officers/12345678", responder)
-
-			res := serveCreateAuthCodeRequestHandler(context.WithValue(context.Background(), authentication.ContextKeyUserDetails, authentication.AuthUserDetails{}), t, &models.AuthCodeRequest{CompanyNumber: "87654321", OfficerID: "12345678"}, nil)
-			So(res.Code, ShouldEqual, http.StatusNotFound)
-			So(res.Body.String(), ShouldStartWith, `{"message":"No officer found"}`)
-		})
-
 		Convey("error calling oracle API for company filing history", func() {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
@@ -163,6 +135,42 @@ func TestUnitCreateAuthCodeRequestHandler(t *testing.T) {
 			res := serveCreateAuthCodeRequestHandler(context.WithValue(context.Background(), authentication.ContextKeyUserDetails, authentication.AuthUserDetails{}), t, &models.AuthCodeRequest{CompanyNumber: "87654321", OfficerID: "12345678"}, mockReqService)
 			So(res.Code, ShouldEqual, http.StatusForbidden)
 			So(res.Body.String(), ShouldStartWith, `{"message":"the company has had a filing within a recent period"}`)
+		})
+
+		Convey("error calling oracle API for officer", func() {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			defer httpmock.Reset()
+
+			// stub the oracle query lookup
+			responder := httpmock.NewStringResponder(http.StatusBadRequest, `{"total_results":3}`)
+			httpmock.RegisterResponder(http.MethodGet, "/emergency-auth-code/company/87654321/eligible-officers/12345678", responder)
+
+			// stub the oracle query lookup for the filing history
+			responderFilingHistory := httpmock.NewStringResponder(http.StatusOK, `{"efiling_found_in_period":false}`)
+			httpmock.RegisterResponder(http.MethodGet, "/emergency-auth-code/company/87654321/efiling-status", responderFilingHistory)
+
+			res := serveCreateAuthCodeRequestHandler(context.WithValue(context.Background(), authentication.ContextKeyUserDetails, authentication.AuthUserDetails{}), t, &models.AuthCodeRequest{CompanyNumber: "87654321", OfficerID: "12345678"}, nil)
+			So(res.Code, ShouldEqual, http.StatusInternalServerError)
+			So(res.Body.String(), ShouldStartWith, `{"message":"there was a problem communicating with the Oracle API"}`)
+		})
+
+		Convey("no officer with that ID found for company", func() {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			defer httpmock.Reset()
+
+			// stub the oracle query lookup
+			responder := httpmock.NewStringResponder(http.StatusNotFound, `{"total_results":3}`)
+			httpmock.RegisterResponder(http.MethodGet, "/emergency-auth-code/company/87654321/eligible-officers/12345678", responder)
+
+			// stub the oracle query lookup for the filing history
+			responderFilingHistory := httpmock.NewStringResponder(http.StatusOK, `{"efiling_found_in_period":false}`)
+			httpmock.RegisterResponder(http.MethodGet, "/emergency-auth-code/company/87654321/efiling-status", responderFilingHistory)
+
+			res := serveCreateAuthCodeRequestHandler(context.WithValue(context.Background(), authentication.ContextKeyUserDetails, authentication.AuthUserDetails{}), t, &models.AuthCodeRequest{CompanyNumber: "87654321", OfficerID: "12345678"}, nil)
+			So(res.Code, ShouldEqual, http.StatusNotFound)
+			So(res.Body.String(), ShouldStartWith, `{"message":"No officer found"}`)
 		})
 
 		Convey("error getting company name", func() {

--- a/oracle/client.go
+++ b/oracle/client.go
@@ -119,6 +119,47 @@ func (c *Client) GetOfficer(companyNumber, officerID string) (*Officer, error) {
 	return out, nil
 }
 
+// CheckFilingHistory will return a count for how many filings have occurred within a recent period
+func (c *Client) CheckFilingHistory(companyNumber string) (*CompanyFilingCheck, error) {
+
+	logContext := log.Data{"company_number": companyNumber}
+
+	path := fmt.Sprintf("/emergency-auth-code/company/%s/efiling-status", companyNumber)
+
+	resp, err := c.sendRequest(http.MethodGet, path)
+
+	// deal with any http transport errors
+	if err != nil {
+		log.Error(err, logContext)
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	// determine if there are unexpected 4xx/5xx errors. an error here relates to a response parsing issue
+	err = c.checkResponseForError(resp)
+	if err != nil {
+		log.Error(err, logContext)
+		return nil, err
+	}
+
+	out := &CompanyFilingCheck{}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err, logContext)
+		return nil, ErrFailedToReadBody
+	}
+
+	err = json.Unmarshal(b, out)
+	if err != nil {
+		log.Error(err, logContext)
+		return nil, ErrFailedToReadBody
+	}
+
+	return out, nil
+}
+
 // Generic function which inspects the http response
 // Returns the response struct or an error if there was a problem reading and parsing the body
 func (c *Client) checkResponseForError(r *http.Response) error {

--- a/oracle/client.go
+++ b/oracle/client.go
@@ -119,7 +119,7 @@ func (c *Client) GetOfficer(companyNumber, officerID string) (*Officer, error) {
 	return out, nil
 }
 
-// CheckFilingHistory will return a count for how many filings have occurred within a recent period
+// CheckFilingHistory will return details of the companies filing history
 func (c *Client) CheckFilingHistory(companyNumber string) (*CompanyFilingCheck, error) {
 
 	logContext := log.Data{"company_number": companyNumber}

--- a/oracle/client_test.go
+++ b/oracle/client_test.go
@@ -199,4 +199,47 @@ func TestUnitGetOfficers(t *testing.T) {
 			So(resp.Occupation, ShouldEqual, "bricklayer")
 		})
 	})
+
+	Convey("Check Filing History", t, func() {
+
+		url := "api-url/emergency-auth-code/company/" + companyNumber + "/efiling-status"
+
+		Convey("Failure to read response", func() {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			client := NewClient("api-url")
+			responder := httpmock.NewStringResponder(http.StatusInternalServerError, "")
+			httpmock.RegisterResponder(http.MethodGet, url, responder)
+
+			resp, err := client.CheckFilingHistory(companyNumber)
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldBeError, ErrFailedToReadBody)
+		})
+
+		Convey("Bad response", func() {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			client := NewClient("api-url")
+			responder := httpmock.NewStringResponder(http.StatusOK, "")
+			httpmock.RegisterResponder(http.MethodGet, url, responder)
+
+			resp, err := client.CheckFilingHistory(companyNumber)
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldBeError, ErrFailedToReadBody)
+		})
+
+		Convey("Successful response", func() {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			client := NewClient("api-url")
+			responder := httpmock.NewStringResponder(http.StatusOK, `{"efiling_found_in_period":false}`)
+			httpmock.RegisterResponder(http.MethodGet, url, responder)
+
+			resp, err := client.CheckFilingHistory(companyNumber)
+			So(err, ShouldBeNil)
+			So(resp.EFilingFoundInPeriod, ShouldBeFalse)
+		})
+	})
 }

--- a/oracle/types.go
+++ b/oracle/types.go
@@ -22,6 +22,11 @@ type Officer struct {
 	UsualResidentialAddress Address     `json:"usual_residential_address"`
 }
 
+// CompanyFilingCheck returns if a filing has happened against the company in a period determined by the oracle-query-api
+type CompanyFilingCheck struct {
+	EFilingFoundInPeriod bool `json:"efiling_found_in_period"`
+}
+
 // DateOfBirth is the month and year of an officer's date of birth
 type DateOfBirth struct {
 	Month string `json:"month"`

--- a/service/officers.go
+++ b/service/officers.go
@@ -93,3 +93,21 @@ func GetOfficerDetails(companyNumber, officerID string) (*oracle.Officer, Respon
 
 	return oracleAPIResponse, Success, nil
 }
+
+// CheckCompanyFilingHistory returns a bool displaying whether the company has filed within the time period or not
+func CheckCompanyFilingHistory(companyNumber string) (bool, error) {
+	cfg, err := config.Get()
+	if err != nil {
+		return false, err
+	}
+
+	client := oracle.NewClient(cfg.OracleQueryAPIURL)
+	filingHistoryCheck, err := client.CheckFilingHistory(companyNumber)
+
+	if err != nil {
+		log.Error(fmt.Errorf("error checking filing history: [%v]", err))
+		return false, err
+	}
+
+	return filingHistoryCheck.EFilingFoundInPeriod, nil
+}

--- a/service/officers_test.go
+++ b/service/officers_test.go
@@ -127,4 +127,29 @@ func TestUnitGetOfficers(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
+
+	Convey("Check Company Filing History ", t, func() {
+
+		url := "/emergency-auth-code/company/" + companyNumber + "/efiling-status"
+
+		Convey("error checking filing history with oracle", func() {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+
+			resp, err := CheckCompanyFilingHistory(companyNumber)
+			So(resp, ShouldBeFalse)
+			So(err.Error(), ShouldContainSubstring, "no responder found")
+		})
+
+		Convey("company filing history returned from oracle", func() {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			responderFilingHistory := httpmock.NewStringResponder(http.StatusOK, `{"efiling_found_in_period":true}`)
+			httpmock.RegisterResponder(http.MethodGet, url, responderFilingHistory)
+
+			resp, err := CheckCompanyFilingHistory(companyNumber)
+			So(resp, ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+	})
 }


### PR DESCRIPTION
Check the company has not filed within a certain time period, determined by the oracle-query-api, before creating an emergency-auth-code request. 

Resolves: BI-4034