### PR TITLE
Check multiple requests for company

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -145,13 +145,13 @@ func (m *MongoService) GetAuthCodeRequest(authCodeRequestID string) (*models.Aut
 }
 
 // CheckMultipleCorporateBodySubmissions checks for multiple submitted requests
-func (m *MongoService) CheckMultipleCorporateBodySubmissions(incorporationNumber string) (bool, error) {
+func (m *MongoService) CheckMultipleCorporateBodySubmissions(companyNumber string) (bool, error) {
 
 	collection := m.db.Collection(m.CollectionName)
 	dbResource := collection.FindOne(
 		context.Background(),
 		bson.M{
-			"data.company_number": incorporationNumber,
+			"data.company_number": companyNumber,
 			"data.status":         "submitted",
 			"data.submitted_at":   bson.M{"$gt": time.Now().AddDate(0, 0, -3)},
 		},

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -143,3 +143,27 @@ func (m *MongoService) GetAuthCodeRequest(authCodeRequestID string) (*models.Aut
 
 	return &resource, nil
 }
+
+// CheckMultipleCorporateBodySubmissions checks for multiple submitted requests
+func (m *MongoService) CheckMultipleCorporateBodySubmissions(incorporationNumber string) (bool, error) {
+
+	collection := m.db.Collection(m.CollectionName)
+	dbResource := collection.FindOne(
+		context.Background(),
+		bson.M{
+			"data.company_number": incorporationNumber,
+			"data.status":         "submitted",
+			"data.submitted_at":   bson.M{"$gt": time.Now().AddDate(0, 0, -3)},
+		},
+	)
+
+	err := dbResource.Err()
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/dao/service.go
+++ b/dao/service.go
@@ -21,6 +21,8 @@ type AuthcodeRequestDAOService interface {
 	UpdateAuthCodeRequestOfficer(dao *models.AuthCodeRequestResourceDao) error
 	// UpdateAuthCodeRequestStatus updates the status in an auth-code-request
 	UpdateAuthCodeRequestStatus(dao *models.AuthCodeRequestResourceDao) error
+	// CheckMultipleCorporateBodySubmissions checks whether multiple requests have been made for a company
+	CheckMultipleCorporateBodySubmissions(incorporationNumber string) (bool, error)
 }
 
 // NewAuthCodeDAOService will create a new instance of the AuthCode Service interface.

--- a/dao/service.go
+++ b/dao/service.go
@@ -22,7 +22,7 @@ type AuthcodeRequestDAOService interface {
 	// UpdateAuthCodeRequestStatus updates the status in an auth-code-request
 	UpdateAuthCodeRequestStatus(dao *models.AuthCodeRequestResourceDao) error
 	// CheckMultipleCorporateBodySubmissions checks whether multiple requests have been made for a company
-	CheckMultipleCorporateBodySubmissions(incorporationNumber string) (bool, error)
+	CheckMultipleCorporateBodySubmissions(companyNumber string) (bool, error)
 }
 
 // NewAuthCodeDAOService will create a new instance of the AuthCode Service interface.

--- a/handlers/auth_code_request_create.go
+++ b/handlers/auth_code_request_create.go
@@ -43,17 +43,14 @@ func CreateAuthCodeRequest(authCodeReqSvc *service.AuthCodeRequestService) http.
 			return
 		}
 
-		hasFiledWithinPeriod, err := service.CheckCompanyFilingHistory(request.CompanyNumber)
+		validCorporateBody, err := validateCorporateBody(req, authCodeReqSvc, request.CompanyNumber)
+
 		if err != nil {
-			log.ErrorR(req, fmt.Errorf("error calling Oracle API to check filing history: %v", err))
-			m := models.NewMessageResponse("there was a problem communicating with the Oracle API")
-			utils.WriteJSONWithStatus(w, req, m, http.StatusInternalServerError)
+			utils.WriteErrorMessage(w, req, http.StatusInternalServerError, "error checking corporate body")
 			return
 		}
-		if hasFiledWithinPeriod {
-			log.Info(fmt.Sprintf("company has had a filing within a recent period: %v", request.CompanyNumber))
-			m := models.NewMessageResponse("the company has had a filing within a recent period")
-			utils.WriteJSONWithStatus(w, req, m, http.StatusForbidden)
+		if !validCorporateBody {
+			utils.WriteResponseMessage(w, req, http.StatusForbidden, "request not permitted for corporate body")
 			return
 		}
 
@@ -109,4 +106,29 @@ func CreateAuthCodeRequest(authCodeReqSvc *service.AuthCodeRequestService) http.
 
 		utils.WriteJSONWithStatus(w, req, transformers.AuthCodeRequestResourceDaoToResponse(model), http.StatusCreated)
 	})
+}
+
+func validateCorporateBody(req *http.Request, authCodeReqSvc *service.AuthCodeRequestService, companyNumber string) (bool, error) {
+
+	// Check whether multiple submissions have been made for company
+	corpBodyMultipleRequests, err := authCodeReqSvc.CheckMultipleCorporateBodySubmissions(companyNumber)
+	if corpBodyMultipleRequests {
+		log.InfoR(req, "Request already submitted for company number "+companyNumber)
+		return false, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// Check whether company has made recent filings
+	hasFiledWithinPeriod, err := service.CheckCompanyFilingHistory(companyNumber)
+	if hasFiledWithinPeriod {
+		log.InfoR(req, "Recent filings found for company number "+companyNumber)
+		return false, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -118,14 +118,14 @@ func (mr *MockAuthcodeRequestDAOServiceMockRecorder) UpdateAuthCodeRequestStatus
 }
 
 // CheckMultipleCorporateBodySubmissions mocks base method
-func (m *MockAuthcodeRequestDAOService) CheckMultipleCorporateBodySubmissions(incorporationNumber string) (bool, error) {
-	ret := m.ctrl.Call(m, "CheckMultipleCorporateBodySubmissions", incorporationNumber)
+func (m *MockAuthcodeRequestDAOService) CheckMultipleCorporateBodySubmissions(companyNumber string) (bool, error) {
+	ret := m.ctrl.Call(m, "CheckMultipleCorporateBodySubmissions", companyNumber)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckMultipleCorporateBodySubmissions indicates an expected call of CheckMultipleCorporateBodySubmissions
-func (mr *MockAuthcodeRequestDAOServiceMockRecorder) CheckMultipleCorporateBodySubmissions(incorporationNumber interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckMultipleCorporateBodySubmissions", reflect.TypeOf((*MockAuthcodeRequestDAOService)(nil).CheckMultipleCorporateBodySubmissions), incorporationNumber)
+func (mr *MockAuthcodeRequestDAOServiceMockRecorder) CheckMultipleCorporateBodySubmissions(companyNumber interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckMultipleCorporateBodySubmissions", reflect.TypeOf((*MockAuthcodeRequestDAOService)(nil).CheckMultipleCorporateBodySubmissions), companyNumber)
 }

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -116,3 +116,16 @@ func (m *MockAuthcodeRequestDAOService) UpdateAuthCodeRequestStatus(dao *models.
 func (mr *MockAuthcodeRequestDAOServiceMockRecorder) UpdateAuthCodeRequestStatus(dao interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAuthCodeRequestStatus", reflect.TypeOf((*MockAuthcodeRequestDAOService)(nil).UpdateAuthCodeRequestStatus), dao)
 }
+
+// CheckMultipleCorporateBodySubmissions mocks base method
+func (m *MockAuthcodeRequestDAOService) CheckMultipleCorporateBodySubmissions(incorporationNumber string) (bool, error) {
+	ret := m.ctrl.Call(m, "CheckMultipleCorporateBodySubmissions", incorporationNumber)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckMultipleCorporateBodySubmissions indicates an expected call of CheckMultipleCorporateBodySubmissions
+func (mr *MockAuthcodeRequestDAOServiceMockRecorder) CheckMultipleCorporateBodySubmissions(incorporationNumber interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckMultipleCorporateBodySubmissions", reflect.TypeOf((*MockAuthcodeRequestDAOService)(nil).CheckMultipleCorporateBodySubmissions), incorporationNumber)
+}

--- a/service/auth_code_request.go
+++ b/service/auth_code_request.go
@@ -179,3 +179,16 @@ func getLetterType(companyHasAuthCode bool) string {
 	}
 	return "apply"
 }
+
+// CheckMultipleCorporateBodySubmissions calls the DB to check for multiple submissions
+func (s *AuthCodeRequestService) CheckMultipleCorporateBodySubmissions(companyNumber string) (bool, error) {
+
+	multipleSubmissions, err := s.DAO.CheckMultipleCorporateBodySubmissions(companyNumber)
+
+	if err != nil {
+		log.Error(fmt.Errorf("error checking corporate body submissions: %v", err))
+		return false, err
+	}
+
+	return multipleSubmissions, nil
+}

--- a/service/auth_code_request_test.go
+++ b/service/auth_code_request_test.go
@@ -13,6 +13,9 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const authCodeRequestID = "123"
+const companyNumber = "87654321"
+
 func TestUnitUpdateAuthCodeRequestOfficer(t *testing.T) {
 
 	Convey("Update Auth Code Request Officer", t, func() {
@@ -28,7 +31,7 @@ func TestUnitUpdateAuthCodeRequestOfficer(t *testing.T) {
 			authCodeReq := models.AuthCodeRequestResourceDao{}
 			officer := oracle.Officer{}
 
-			responseType := svc.UpdateAuthCodeRequestOfficer(&authCodeReq, "123", &officer)
+			responseType := svc.UpdateAuthCodeRequestOfficer(&authCodeReq, authCodeRequestID, &officer)
 			So(responseType, ShouldEqual, Error)
 		})
 
@@ -43,7 +46,7 @@ func TestUnitUpdateAuthCodeRequestOfficer(t *testing.T) {
 			authCodeReq := models.AuthCodeRequestResourceDao{}
 			officer := oracle.Officer{}
 
-			responseType := svc.UpdateAuthCodeRequestOfficer(&authCodeReq, "123", &officer)
+			responseType := svc.UpdateAuthCodeRequestOfficer(&authCodeReq, authCodeRequestID, &officer)
 			So(responseType, ShouldEqual, Success)
 		})
 	})
@@ -62,7 +65,7 @@ func TestUnitUpdateAuthCodeRequestStatus(t *testing.T) {
 
 			authCodeReq := models.AuthCodeRequestResourceDao{}
 
-			responseType := svc.UpdateAuthCodeRequestStatusSubmitted(&authCodeReq, "123", false)
+			responseType := svc.UpdateAuthCodeRequestStatusSubmitted(&authCodeReq, authCodeRequestID, false)
 			So(responseType, ShouldEqual, Error)
 		})
 
@@ -76,7 +79,7 @@ func TestUnitUpdateAuthCodeRequestStatus(t *testing.T) {
 
 			authCodeReq := models.AuthCodeRequestResourceDao{}
 
-			responseType := svc.UpdateAuthCodeRequestStatusSubmitted(&authCodeReq, "123", false)
+			responseType := svc.UpdateAuthCodeRequestStatusSubmitted(&authCodeReq, authCodeRequestID, false)
 			So(responseType, ShouldEqual, Success)
 		})
 	})
@@ -104,7 +107,7 @@ func TestUnitSendAuthCodeRequest(t *testing.T) {
 				},
 			}
 
-			responseType := svc.SendAuthCodeRequest(&authCodeReq, "87654321", "email@companieshouse.gov.uk", true)
+			responseType := svc.SendAuthCodeRequest(&authCodeReq, companyNumber, "email@companieshouse.gov.uk", true)
 			So(responseType, ShouldEqual, Error)
 
 		})
@@ -127,7 +130,7 @@ func TestUnitSendAuthCodeRequest(t *testing.T) {
 				},
 			}
 
-			responseType := svc.SendAuthCodeRequest(&authCodeReq, "87654321", "email@companieshouse.gov.uk", true)
+			responseType := svc.SendAuthCodeRequest(&authCodeReq, companyNumber, "email@companieshouse.gov.uk", true)
 			So(responseType, ShouldEqual, NotFound)
 		})
 
@@ -149,7 +152,7 @@ func TestUnitSendAuthCodeRequest(t *testing.T) {
 				},
 			}
 
-			responseType := svc.SendAuthCodeRequest(&authCodeReq, "87654321", "email@companieshouse.gov.uk", true)
+			responseType := svc.SendAuthCodeRequest(&authCodeReq, companyNumber, "email@companieshouse.gov.uk", true)
 			So(responseType, ShouldEqual, Error)
 		})
 
@@ -173,14 +176,13 @@ func TestUnitSendAuthCodeRequest(t *testing.T) {
 				},
 			}
 
-			responseType := svc.SendAuthCodeRequest(&authCodeReq, "87654321", "email@companieshouse.gov.uk", true)
+			responseType := svc.SendAuthCodeRequest(&authCodeReq, companyNumber, "email@companieshouse.gov.uk", true)
 			So(responseType, ShouldEqual, Success)
 		})
 	})
 }
 
 func TestUnitGetAuthCodeReqDao(t *testing.T) {
-	companyNumber := "87654321"
 	Convey("Get Auth Code Request DAO", t, func() {
 		Convey("error getting request", func() {
 			mockCtrl := gomock.NewController(t)
@@ -190,7 +192,7 @@ func TestUnitGetAuthCodeReqDao(t *testing.T) {
 			mockDaoService.EXPECT().GetAuthCodeRequest(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			svc := AuthCodeRequestService{DAO: mockDaoService}
 
-			request, responseType := svc.GetAuthCodeReqDao("123", companyNumber)
+			request, responseType := svc.GetAuthCodeReqDao(authCodeRequestID, companyNumber)
 			So(request, ShouldBeNil)
 			So(responseType, ShouldEqual, Error)
 		})
@@ -203,7 +205,7 @@ func TestUnitGetAuthCodeReqDao(t *testing.T) {
 			mockDaoService.EXPECT().GetAuthCodeRequest(gomock.Any()).Return(nil, nil)
 			svc := AuthCodeRequestService{DAO: mockDaoService}
 
-			request, responseType := svc.GetAuthCodeReqDao("123", companyNumber)
+			request, responseType := svc.GetAuthCodeReqDao(authCodeRequestID, companyNumber)
 			So(request, ShouldBeNil)
 			So(responseType, ShouldEqual, NotFound)
 		})
@@ -221,7 +223,7 @@ func TestUnitGetAuthCodeReqDao(t *testing.T) {
 			mockDaoService.EXPECT().GetAuthCodeRequest(gomock.Any()).Return(&response, nil)
 			svc := AuthCodeRequestService{DAO: mockDaoService}
 
-			request, responseType := svc.GetAuthCodeReqDao("123", companyNumber)
+			request, responseType := svc.GetAuthCodeReqDao(authCodeRequestID, companyNumber)
 			So(request, ShouldBeNil)
 			So(responseType, ShouldEqual, InvalidData)
 		})
@@ -239,7 +241,7 @@ func TestUnitGetAuthCodeReqDao(t *testing.T) {
 			mockDaoService.EXPECT().GetAuthCodeRequest(gomock.Any()).Return(&response, nil)
 			svc := AuthCodeRequestService{DAO: mockDaoService}
 
-			request, responseType := svc.GetAuthCodeReqDao("123", companyNumber)
+			request, responseType := svc.GetAuthCodeReqDao(authCodeRequestID, companyNumber)
 			So(request.Data.CompanyNumber, ShouldEqual, companyNumber)
 			So(responseType, ShouldEqual, Success)
 		})
@@ -250,5 +252,38 @@ func TestUnitGetLetterType(t *testing.T) {
 	Convey("get letter type", t, func() {
 		So(getLetterType(true), ShouldEqual, "reminder")
 		So(getLetterType(false), ShouldEqual, "apply")
+	})
+}
+
+func TestUnitCheckMultipleCorporateBodySubmissions(t *testing.T) {
+
+	Convey("Check Multiple Corporate Body Submissions", t, func() {
+		Convey("Error checking submissions", func() {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			errorMessage := "error test"
+			mockDaoService := mocks.NewMockAuthcodeRequestDAOService(mockCtrl)
+			mockDaoService.EXPECT().CheckMultipleCorporateBodySubmissions(gomock.Any()).Return(false, fmt.Errorf(errorMessage))
+			svc := AuthCodeRequestService{DAO: mockDaoService}
+
+			response, err := svc.CheckMultipleCorporateBodySubmissions(companyNumber)
+			So(response, ShouldBeFalse)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, errorMessage)
+		})
+
+		Convey("Company has multiple submissions", func() {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockDaoService := mocks.NewMockAuthcodeRequestDAOService(mockCtrl)
+			mockDaoService.EXPECT().CheckMultipleCorporateBodySubmissions(gomock.Any()).Return(true, nil)
+			svc := AuthCodeRequestService{DAO: mockDaoService}
+
+			response, err := svc.CheckMultipleCorporateBodySubmissions(companyNumber)
+			So(response, ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
 	})
 }


### PR DESCRIPTION
Check authcode requests in mongo.
Return 403 if company has requested authcode in the preceding 72 hours.

Combine with existing check for recent filings into validateCompany function.