### PR TITLE
Upsert authcode

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -74,6 +74,14 @@ func (m *MongoService) CompanyHasAuthCode(companyNumber string) (bool, error) {
 	return false, nil
 }
 
+// UpsertEmptyAuthCode updates an authcode, or inserts if not already present
+func (m *MongoService) UpsertEmptyAuthCode(companyNumber string) error {
+	collection := m.db.Collection(m.CollectionName)
+	opts := options.Update().SetUpsert(true)
+	_, err := collection.UpdateOne(context.Background(), bson.M{"_id": companyNumber}, bson.M{"$set": bson.M{"_id": companyNumber}}, opts)
+	return err
+}
+
 // InsertAuthCodeRequest inserts an auth code request into the db
 func (m *MongoService) InsertAuthCodeRequest(dao *models.AuthCodeRequestResourceDao) error {
 	collection := m.db.Collection(m.CollectionName)

--- a/dao/service.go
+++ b/dao/service.go
@@ -9,6 +9,8 @@ import (
 type AuthcodeDAOService interface {
 	// CompanyHasAuthCode will check if the supplied company number has an auth code
 	CompanyHasAuthCode(companyNumber string) (bool, error)
+	// UpsertEmptyAuthCode updates an authcode, or inserts if not already present
+	UpsertEmptyAuthCode(companyNumber string) error
 }
 
 // AuthcodeRequestDAOService interface declares how to interact with the persistence layer regardless of underlying technology

--- a/handlers/auth_code_request_update_test.go
+++ b/handlers/auth_code_request_update_test.go
@@ -263,6 +263,7 @@ func TestUnitUpdateAuthCodeRequestHandler(t *testing.T) {
 
 				mockDaoAuthcodeService := mocks.NewMockAuthcodeDAOService(mockCtrl)
 				mockDaoAuthcodeService.EXPECT().CompanyHasAuthCode(gomock.Any()).Return(false, fmt.Errorf("error"))
+				mockDaoAuthcodeService.EXPECT().UpsertEmptyAuthCode(gomock.Any()).Return(nil)
 
 				res := serveUpdateAuthCodeRequestHandler(context.WithValue(context.Background(), authentication.ContextKeyUserDetails, authentication.AuthUserDetails{}), t, &models.AuthCodeRequest{CompanyNumber: "87654321", Status: "submitted"}, "123", mockDaoAuthcodeService, mockDaoReqService)
 				So(res.Code, ShouldEqual, http.StatusInternalServerError)
@@ -285,6 +286,7 @@ func TestUnitUpdateAuthCodeRequestHandler(t *testing.T) {
 
 				mockDaoAuthcodeService := mocks.NewMockAuthcodeDAOService(mockCtrl)
 				mockDaoAuthcodeService.EXPECT().CompanyHasAuthCode(gomock.Any()).Return(false, nil)
+				mockDaoAuthcodeService.EXPECT().UpsertEmptyAuthCode(gomock.Any()).Return(nil)
 
 				res := serveUpdateAuthCodeRequestHandler(context.WithValue(context.Background(), authentication.ContextKeyUserDetails, authentication.AuthUserDetails{}), t, &models.AuthCodeRequest{CompanyNumber: "87654321", Status: "submitted"}, "123", mockDaoAuthcodeService, mockDaoReqService)
 				So(res.Code, ShouldEqual, http.StatusInternalServerError)
@@ -307,6 +309,7 @@ func TestUnitUpdateAuthCodeRequestHandler(t *testing.T) {
 
 				mockDaoAuthcodeService := mocks.NewMockAuthcodeDAOService(mockCtrl)
 				mockDaoAuthcodeService.EXPECT().CompanyHasAuthCode(gomock.Any()).Return(false, nil)
+				mockDaoAuthcodeService.EXPECT().UpsertEmptyAuthCode(gomock.Any()).Return(nil)
 
 				httpmock.Activate()
 				defer httpmock.DeactivateAndReset()
@@ -336,6 +339,7 @@ func TestUnitUpdateAuthCodeRequestHandler(t *testing.T) {
 
 				mockDaoAuthcodeService := mocks.NewMockAuthcodeDAOService(mockCtrl)
 				mockDaoAuthcodeService.EXPECT().CompanyHasAuthCode(gomock.Any()).Return(false, nil)
+				mockDaoAuthcodeService.EXPECT().UpsertEmptyAuthCode(gomock.Any()).Return(nil)
 
 				httpmock.Activate()
 				defer httpmock.DeactivateAndReset()
@@ -366,6 +370,7 @@ func TestUnitUpdateAuthCodeRequestHandler(t *testing.T) {
 
 				mockDaoAuthcodeService := mocks.NewMockAuthcodeDAOService(mockCtrl)
 				mockDaoAuthcodeService.EXPECT().CompanyHasAuthCode(gomock.Any()).Return(false, nil)
+				mockDaoAuthcodeService.EXPECT().UpsertEmptyAuthCode(gomock.Any()).Return(nil)
 
 				httpmock.Activate()
 				defer httpmock.DeactivateAndReset()

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -45,6 +45,18 @@ func (mr *MockAuthcodeDAOServiceMockRecorder) CompanyHasAuthCode(companyNumber i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompanyHasAuthCode", reflect.TypeOf((*MockAuthcodeDAOService)(nil).CompanyHasAuthCode), companyNumber)
 }
 
+// UpsertEmptyAuthCode mocks base method
+func (m *MockAuthcodeDAOService) UpsertEmptyAuthCode(companyNumber string) error {
+	ret := m.ctrl.Call(m, "UpsertEmptyAuthCode", companyNumber)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertEmptyAuthCode indicates an expected call of UpsertEmptyAuthCode
+func (mr *MockAuthcodeDAOServiceMockRecorder) UpsertEmptyAuthCode(companyNumber interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertEmptyAuthCode", reflect.TypeOf((*MockAuthcodeDAOService)(nil).UpsertEmptyAuthCode), companyNumber)
+}
+
 // MockAuthcodeRequestDAOService is a mock of AuthcodeRequestDAOService interface
 type MockAuthcodeRequestDAOService struct {
 	ctrl     *gomock.Controller

--- a/service/auth_code.go
+++ b/service/auth_code.go
@@ -20,5 +20,13 @@ func (s *AuthCodeService) CheckAuthCodeExists(companyNumber string) (bool, error
 		err = fmt.Errorf("error checking DB for auth code: [%v]", err)
 	}
 
+	if !companyHasAuthCode {
+		// backend processing expects an authcode item to exist, so need to create one here
+		err := s.DAO.UpsertEmptyAuthCode(companyNumber)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	return companyHasAuthCode, err
 }

--- a/service/auth_code_test.go
+++ b/service/auth_code_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/companieshouse/emergency-auth-code-api/mocks"
@@ -18,6 +19,7 @@ func TestUnitCheckAuthCode(t *testing.T) {
 
 			mockDaoService := mocks.NewMockAuthcodeDAOService(mockCtrl)
 			mockDaoService.EXPECT().CompanyHasAuthCode(gomock.Any()).Return(false, errors.New("error"))
+			mockDaoService.EXPECT().UpsertEmptyAuthCode(gomock.Any()).Return(nil)
 			svc := AuthCodeService{DAO: mockDaoService}
 
 			_, err := svc.CheckAuthCodeExists("87654321")
@@ -31,10 +33,25 @@ func TestUnitCheckAuthCode(t *testing.T) {
 
 			mockDaoService := mocks.NewMockAuthcodeDAOService(mockCtrl)
 			mockDaoService.EXPECT().CompanyHasAuthCode(gomock.Any()).Return(false, nil)
+			mockDaoService.EXPECT().UpsertEmptyAuthCode(gomock.Any()).Return(nil)
 			svc := AuthCodeService{DAO: mockDaoService}
 
 			companyHasAuthCode, err := svc.CheckAuthCodeExists("87654321")
 			So(err, ShouldBeNil)
+			So(companyHasAuthCode, ShouldBeFalse)
+		})
+
+		Convey("Error upserting authcode", func() {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockDaoService := mocks.NewMockAuthcodeDAOService(mockCtrl)
+			mockDaoService.EXPECT().CompanyHasAuthCode(gomock.Any()).Return(false, nil)
+			mockDaoService.EXPECT().UpsertEmptyAuthCode(gomock.Any()).Return(fmt.Errorf("error"))
+			svc := AuthCodeService{DAO: mockDaoService}
+
+			companyHasAuthCode, err := svc.CheckAuthCodeExists("87654321")
+			So(err, ShouldNotBeNil)
 			So(companyHasAuthCode, ShouldBeFalse)
 		})
 


### PR DESCRIPTION
Backend processing expects an authcode item to exist in the DB, so need to upsert one as part of the PUT endpoint.

BI-4108