### PR TITLE
Add query params in GetOfficers method to allow pagination

### DIFF
--- a/handlers/get_company_officers.go
+++ b/handlers/get_company_officers.go
@@ -25,9 +25,12 @@ func GetCompanyOfficers(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	startIndex := req.FormValue("start_index")
+	itemsPerPage := req.FormValue("items_per_page")
+
 	companyNumber = strings.ToUpper(companyNumber)
 
-	companyOfficers, responseType, err := service.GetOfficers(companyNumber)
+	companyOfficers, responseType, err := service.GetOfficers(companyNumber, startIndex, itemsPerPage)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error calling Oracle API to get officers: %v", err))
 		m := models.NewMessageResponse("there was a problem communicating with the Oracle API")

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -39,7 +39,7 @@ func Register(mainRouter *mux.Router, cfg *config.Config, authCodeDao dao.Authco
 	appRouter.Use(userAuthInterceptor.UserAuthenticationIntercept)
 
 	// Declare endpoint URIs
-	appRouter.HandleFunc("/company/{company_number}/officers", GetCompanyOfficers).Queries("start_index", "{start_index:([0-9]+)?}", "items_per_page", "{items_per_page:([0-9]+)?}").Methods(http.MethodGet).Name("get-company-officers")
+	appRouter.HandleFunc("/company/{company_number}/officers", GetCompanyOfficers).Methods(http.MethodGet).Name("get-company-officers")
 	appRouter.HandleFunc("/company/{company_number}/officers/{officer_id}", GetCompanyOfficer).Methods(http.MethodGet).Name("get-company-officer")
 	appRouter.Handle("/auth-code-requests", CreateAuthCodeRequest(authCodeRequestService)).Methods(http.MethodPost).Name("create-auth-code-request")
 	appRouter.Handle("/auth-code-requests/{auth_code_request_id}", GetAuthCodeRequest(authCodeRequestService)).Methods(http.MethodGet).Name("get-auth-code-request")

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -39,7 +39,7 @@ func Register(mainRouter *mux.Router, cfg *config.Config, authCodeDao dao.Authco
 	appRouter.Use(userAuthInterceptor.UserAuthenticationIntercept)
 
 	// Declare endpoint URIs
-	appRouter.HandleFunc("/company/{company_number}/officers", GetCompanyOfficers).Methods(http.MethodGet).Name("get-company-officers")
+	appRouter.HandleFunc("/company/{company_number}/officers", GetCompanyOfficers).Queries("start_index", "{start_index:([0-9]+)?}", "items_per_page", "{items_per_page:([0-9]+)?}").Methods(http.MethodGet).Name("get-company-officers")
 	appRouter.HandleFunc("/company/{company_number}/officers/{officer_id}", GetCompanyOfficer).Methods(http.MethodGet).Name("get-company-officer")
 	appRouter.Handle("/auth-code-requests", CreateAuthCodeRequest(authCodeRequestService)).Methods(http.MethodPost).Name("create-auth-code-request")
 	appRouter.Handle("/auth-code-requests/{auth_code_request_id}", GetAuthCodeRequest(authCodeRequestService)).Methods(http.MethodGet).Name("get-auth-code-request")

--- a/oracle/client.go
+++ b/oracle/client.go
@@ -30,11 +30,11 @@ type Client struct {
 }
 
 // GetOfficers will return a list of officers for a company
-func (c *Client) GetOfficers(companyNumber string) (*GetOfficersResponse, error) {
+func (c *Client) GetOfficers(companyNumber string, startIndex string, itemsPerPage string) (*GetOfficersResponse, error) {
 
 	logContext := log.Data{"company_number": companyNumber}
 
-	path := fmt.Sprintf("/emergency-auth-code/company/%s/eligible-officers", companyNumber)
+	path := fmt.Sprintf("/emergency-auth-code/company/%s/eligible-officers?start_index=%s&items_per_page=%s", companyNumber, startIndex, itemsPerPage)
 
 	resp, err := c.sendRequest(http.MethodGet, path)
 

--- a/oracle/client_test.go
+++ b/oracle/client_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestUnitGetOfficers(t *testing.T) {
 	companyNumber := "87654321"
+	startIndex := "0"
+	itemsPerPage := "15"
 
 	Convey("Get Officer List", t, func() {
 
@@ -22,7 +24,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusNotFound, "")
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, err := client.GetOfficers(companyNumber)
+			resp, err := client.GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp, ShouldBeNil)
 			So(err, ShouldBeNil)
 		})
@@ -34,7 +36,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusInternalServerError, "")
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, err := client.GetOfficers(companyNumber)
+			resp, err := client.GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldBeError, ErrFailedToReadBody)
@@ -47,7 +49,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusBadRequest, `{"httpStatusCode" : 500}`)
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, err := client.GetOfficers(companyNumber)
+			resp, err := client.GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldBeError, ErrOracleAPIBadRequest)
@@ -60,7 +62,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusInternalServerError, `{"httpStatusCode" : 500}`)
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, err := client.GetOfficers(companyNumber)
+			resp, err := client.GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldBeError, ErrOracleAPIInternalServer)
@@ -73,7 +75,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusTeapot, `{"httpStatusCode" : 500}`)
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, err := client.GetOfficers(companyNumber)
+			resp, err := client.GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldBeError, ErrUnexpectedServerError)
@@ -86,7 +88,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusOK, "")
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, err := client.GetOfficers(companyNumber)
+			resp, err := client.GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldBeError, ErrFailedToReadBody)
@@ -99,7 +101,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusOK, `{"total_results":3}`)
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, err := client.GetOfficers(companyNumber)
+			resp, err := client.GetOfficers(companyNumber, startIndex, companyNumber)
 			So(err, ShouldBeNil)
 			So(resp.TotalResults, ShouldEqual, 3)
 		})

--- a/service/officers.go
+++ b/service/officers.go
@@ -23,8 +23,8 @@ func GetOfficers(companyNumber string, startIndex string, itemsPerPage string) (
 }
 
 // CheckOfficers checks if a company has any eligible officers
-func CheckOfficers(companyNumber string, startIndex string, itemsPerPage string) (bool, error) {
-	_, responseType, err := getOfficers(companyNumber, startIndex, itemsPerPage)
+func CheckOfficers(companyNumber string) (bool, error) {
+	_, responseType, err := getOfficers(companyNumber, "", "")
 	if err != nil {
 		return false, err
 	}

--- a/service/officers.go
+++ b/service/officers.go
@@ -11,8 +11,8 @@ import (
 )
 
 // GetOfficers returns the list of officers for the supplied company number
-func GetOfficers(companyNumber string) (*models.OfficerListResponse, ResponseType, error) {
-	oracleAPIResponse, responseType, err := getOfficers(companyNumber)
+func GetOfficers(companyNumber string, startIndex string, itemsPerPage string) (*models.OfficerListResponse, ResponseType, error) {
+	oracleAPIResponse, responseType, err := getOfficers(companyNumber, startIndex, itemsPerPage)
 	if err != nil || responseType != Success {
 		return nil, responseType, err
 	}
@@ -23,8 +23,8 @@ func GetOfficers(companyNumber string) (*models.OfficerListResponse, ResponseTyp
 }
 
 // CheckOfficers checks if a company has any eligible officers
-func CheckOfficers(companyNumber string) (bool, error) {
-	_, responseType, err := getOfficers(companyNumber)
+func CheckOfficers(companyNumber string, startIndex string, itemsPerPage string) (bool, error) {
+	_, responseType, err := getOfficers(companyNumber, startIndex, itemsPerPage)
 	if err != nil {
 		return false, err
 	}
@@ -35,14 +35,14 @@ func CheckOfficers(companyNumber string) (bool, error) {
 	return true, nil
 }
 
-func getOfficers(companyNumber string) (*oracle.GetOfficersResponse, ResponseType, error) {
+func getOfficers(companyNumber string, startIndex string, itemsPerPage string) (*oracle.GetOfficersResponse, ResponseType, error) {
 	cfg, err := config.Get()
 	if err != nil {
 		return nil, Error, nil
 	}
 
 	client := oracle.NewClient(cfg.OracleQueryAPIURL)
-	oracleAPIResponse, err := client.GetOfficers(companyNumber)
+	oracleAPIResponse, err := client.GetOfficers(companyNumber, startIndex, itemsPerPage)
 
 	if err != nil {
 		log.Error(fmt.Errorf("error getting officer list: [%v]", err))

--- a/service/officers_test.go
+++ b/service/officers_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestUnitGetOfficers(t *testing.T) {
 	companyNumber := "87654321"
+	startIndex := "0"
+	itemsPerPage := "15"
 
 	Convey("Get Officer List", t, func() {
 
@@ -19,7 +21,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			httpmock.Activate()
 			defer httpmock.DeactivateAndReset()
 
-			resp, respType, err := GetOfficers(companyNumber)
+			resp, respType, err := GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp, ShouldBeNil)
 			So(respType, ShouldEqual, Error)
 			So(err.Error(), ShouldContainSubstring, "no responder found")
@@ -31,7 +33,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusNotFound, "")
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, respType, err := GetOfficers(companyNumber)
+			resp, respType, err := GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp, ShouldBeNil)
 			So(respType, ShouldEqual, NotFound)
 			So(err, ShouldBeNil)
@@ -43,7 +45,7 @@ func TestUnitGetOfficers(t *testing.T) {
 			responder := httpmock.NewStringResponder(http.StatusOK, `{"total_results":3}`)
 			httpmock.RegisterResponder(http.MethodGet, url, responder)
 
-			resp, respType, err := GetOfficers(companyNumber)
+			resp, respType, err := GetOfficers(companyNumber, startIndex, itemsPerPage)
 			So(resp.TotalResults, ShouldEqual, 3)
 			So(respType, ShouldEqual, Success)
 			So(err, ShouldBeNil)


### PR DESCRIPTION
- The params were retrieved from the request using the `FormValue` method
- The 2 params were also added as vars and the required unit tests were then updated