### PR TITLE
Update service to use new authcode api flow and make this flow configurable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ lint.txt
 # Mac files
 .DS_Store
 ._*
+
+# Test Coverage Output
+coverage.out
+
+# vs code
+.vscode/
+

--- a/authcodeapi/client.go
+++ b/authcodeapi/client.go
@@ -1,5 +1,5 @@
-// Package queueapi connects and sends requests to the Queue API
-package queueapi
+// Package authcodeapi connects and sends requests to the authcode api flow
+package authcodeapi
 
 import (
 	"bytes"
@@ -11,21 +11,23 @@ import (
 	"github.com/companieshouse/emergency-auth-code-api/models"
 )
 
-// Client interacts with the Queue API
+// Client interacts with the AuthCode API
 type Client struct {
-	QueueAPIURL string
+	AuthCodeAPIURL  string
+	AuthCodeAPIPath string
 }
 
 // NewClient will construct a new client service struct that can be used to interact with the Client API
-func NewClient(queueAPIURL string) *Client {
+func NewClient(authCodeAPIURL, authCodeAPIPath string) *Client {
 	return &Client{
-		QueueAPIURL: queueAPIURL,
+		AuthCodeAPIURL:  authCodeAPIURL,
+		AuthCodeAPIPath: authCodeAPIPath,
 	}
 }
 
 // sendRequest will make a http request and unmarshal the response body into a struct
-func (c *Client) sendRequest(method, path string, item *models.QueueItem) (*http.Response, error) {
-	url := c.QueueAPIURL + path
+func (c *Client) sendRequest(method, path string, item *models.AuthCodeItem) (*http.Response, error) {
+	url := c.AuthCodeAPIURL + path
 
 	reqBody, err := json.Marshal(item)
 	if err != nil {
@@ -52,25 +54,20 @@ func (c *Client) sendRequest(method, path string, item *models.QueueItem) (*http
 	return resp, err
 }
 
-// SendQueueItem sends an item to the Queue API
-func (c *Client) SendQueueItem(item *models.QueueItem) error {
-
-	path := "/api/queue/authcode"
-
-	resp, err := c.sendRequest(http.MethodPost, path, item)
+// SendAuthCodeItem sends an item to the AuthCode API
+func (c *Client) SendAuthCodeItem(item *models.AuthCodeItem) error {
+	resp, err := c.sendRequest(http.MethodPost, c.AuthCodeAPIPath, item)
 	if err != nil {
-		log.Error(fmt.Errorf("error sending request to queue API: %v", err))
+		log.Error(fmt.Errorf("error sending request to authCode API: %v", err))
 		return err
 	}
 	err = resp.Body.Close()
 	if err != nil {
-		log.Error(fmt.Errorf("error closing response body from Queue API: %v", err))
+		log.Error(fmt.Errorf("error closing response body from AuthCode API: %v", err))
 		// No need to return err here, as sending request might have been successful
 	}
-
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status returned from queue API: %v", resp.StatusCode)
+		return fmt.Errorf("unexpected status returned from authCode API: %v", resp.StatusCode)
 	}
-
 	return nil
 }

--- a/authcodeapi/client_test.go
+++ b/authcodeapi/client_test.go
@@ -1,4 +1,4 @@
-package queueapi
+package authcodeapi
 
 import (
 	"net/http"
@@ -9,30 +9,31 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestUnitSendQueueItem(t *testing.T) {
+func TestUnitSendAuthCodeItem(t *testing.T) {
 	url := "api-url"
-	queueAPIURL := url + "/api/queue/authcode"
-	queueItem := models.QueueItem{}
+	path := "/api/test/authcode"
+	queueAPIURL := url + path
+	AuthCodeItem := models.AuthCodeItem{}
 
-	Convey("unexpected status returned from queue API", t, func() {
+	Convey("unexpected status returned from authcode API", t, func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		client := NewClient(url)
+		client := NewClient(url, path)
 		responder := httpmock.NewStringResponder(http.StatusNotFound, "")
 		httpmock.RegisterResponder(http.MethodPost, queueAPIURL, responder)
 
-		err := client.SendQueueItem(&queueItem)
-		So(err.Error(), ShouldEqual, "unexpected status returned from queue API: 404")
+		err := client.SendAuthCodeItem(&AuthCodeItem)
+		So(err.Error(), ShouldEqual, "unexpected status returned from authCode API: 404")
 	})
 
 	Convey("queue API - success", t, func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		client := NewClient(url)
+		client := NewClient(url, path)
 		responder := httpmock.NewStringResponder(http.StatusOK, "error")
 		httpmock.RegisterResponder(http.MethodPost, queueAPIURL, responder)
 
-		err := client.SendQueueItem(&queueItem)
+		err := client.SendAuthCodeItem(&AuthCodeItem)
 		So(err, ShouldBeNil)
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -20,9 +20,13 @@ type Config struct {
 	MongoAuthCodeRequestCollection string   `env:"MONGO_AUTHCODE_REQUEST_COLLECTION" flag:"mongodb-authcode-request-collection" flagDesc:"The name of the mongodb auth code request collection"`
 	OracleQueryAPIURL              string   `env:"ORACLE_QUERY_API_URL"              flag:"oracle-query-api-url"                flagDesc:"Oracle Query API URL"`
 	QueueAPILocalURL               string   `env:"QUEUE_API_LOCAL_URL"               flag:"queue-api-local-url"                 flagDesc:"Queue API Local URL"`
+	AuthCodeAPILocalURL            string   `env:"AUTHCODE_API_LOCAL_URL"            flag:"authcode-api-local-url"              flagDesc:"AuthCode API Local URL"`
+	QueueAPILocalPath              string   `env:"QUEUE_API_LOCAL_PATH"              flag:"queue-api-local-path"                flagDesc:"Queue API Local Path"`
+	AuthCodeAPILocalPath           string   `env:"AUTHCODE_API_LOCAL_PATH"           flag:"authcode-api-local-path"             flagDesc:"AuthCode API Local Path"`
 	BrokerAddr                     []string `env:"KAFKA_BROKER_ADDR"                 flag:"broker-addr"                         flagDesc:"Kafka broker address"`
 	SchemaRegistryURL              string   `env:"SCHEMA_REGISTRY_URL"               flag:"schema-registry-url"                 flagDesc:"Schema registry url"`
 	CHSURL                         string   `env:"CHS_URL"                           flag:"chs-url"                             flagDesc:"CHS URL"`
+	NewAuthCodeAPIFlow             bool   `env:"NEW_AUTHCODE_API_FLOW"             flag:"new-authcode-api-flow"             	flagDesc:"New AuthCode API Flow ["true"|"false"]"`
 }
 
 // Get returns a pointer to a Config instance populated with values from environment or command-line flags

--- a/models/queue.go
+++ b/models/queue.go
@@ -1,7 +1,7 @@
 package models
 
-// QueueItem is authcode data to be sent to chs-queue-api
-type QueueItem struct {
+// AuthCodeItem is authcode data to be sent to chs-queue-api
+type AuthCodeItem struct {
 	Type          string  `json:"type"`
 	Email         string  `json:"email"`
 	CompanyNumber string  `json:"company_number"`


### PR DESCRIPTION
As per title. Adds logic to control which `authcode flow` (`mongo queue and chs-backend` *or* `authcode-api`) that authcode requests get routed to.

Controlled using env var `bool` flag:

- `NEW_AUTHCODE_API_FLOW = false` : `mongo queue and chs-backend` authcode flow
- `NEW_AUTHCODE_API_FLOW = true` :  `new authcode-api` authcode flow